### PR TITLE
busybot: add readme and deploy.yaml

### DIFF
--- a/busybot/README.md
+++ b/busybot/README.md
@@ -2,9 +2,10 @@
 
 This is a simple app to fill the demo environment with dummy data. Here's what it does:
 
-1. Read a random set of 5 files.
+1. List files and read a random set of 5 files.
 2. Write a random set of 5 files; allow overwrites.
+3. List files and delete a random set of 2 files
 
-Each file is of size 50MB. The files are numbered 00-99. All files will be generated beforehand to prevent a case where a file is missing.
+Each file is of size 50MB. The files are numbered 00-99.
 
 This will be run using a k8s cronjob every two minutes. The yaml file for the cronjob is included in this folder. CephFS is used since filesystem interface is the easiest to use. We will echo the time it took to write/read each file into logs. To ensure the whole file is read, an md5 will be calculated and out in logs.

--- a/busybot/README.md
+++ b/busybot/README.md
@@ -1,0 +1,10 @@
+# Demo busybot
+
+This is a simple app to fill the demo environment with dummy data. Here's what it does:
+
+1. Read a random set of 5 files.
+2. Write a random set of 5 files; allow overwrites.
+
+Each file is of size 50MB. The files are numbered 00-99. All files will be generated beforehand to prevent a case where a file is missing.
+
+This will be run using a k8s cronjob every two minutes. The yaml file for the cronjob is included in this folder. CephFS is used since filesystem interface is the easiest to use. We will echo the time it took to write/read each file into logs. To ensure the whole file is read, an md5 will be calculated and out in logs.

--- a/busybot/deploy.yaml
+++ b/busybot/deploy.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: busybot-cephfs-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 11Gi
+  storageClassName: ceph-filesystem
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: busybot
+spec:
+  schedule: "*/2 * * * *"
+  successfulJobsHistoryLimit: 5
+  failedJobsHistoryLimit: 5
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    metadata:          
+      labels:
+        app: busybot
+        cron: busybot
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: alpine:3.18.4
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 100Mi
+            env:
+            - name: STORE
+              value: /store
+            - name: COUNT
+              value: "5"
+            - name: SIZE
+              value: 50M
+            volumeMounts:
+            - name: busybot-store
+              mountPath: /store
+            command:
+            - /bin/sh
+            - -c
+            - |
+              # Read $COUNT random files from store and calculate md5
+              ls $STORE | shuf -n $COUNT | while read file
+              do
+                echo Reading $file
+                md5sum $STORE/$file
+              done
+
+              # Write $COUNT random files from store and calculate md5
+              shuf -n $COUNT -i 0-99 | while read file
+              do
+                filename=$(printf "%02d" $file)
+                echo Writing $filename
+                dd if=/dev/urandom of=$STORE/$filename bs=$SIZE count=1
+              done
+          restartPolicy: Never
+          volumes:
+          - name: busybot-store
+            persistentVolumeClaim:
+              claimName: busybot-cephfs-pvc
+              readOnly: false

--- a/busybot/deploy.yaml
+++ b/busybot/deploy.yaml
@@ -40,6 +40,8 @@ spec:
               value: /store
             - name: COUNT
               value: "5"
+            - name: DEL_COUNT
+              value: "5"
             - name: SIZE
               value: 50M
             volumeMounts:
@@ -56,12 +58,19 @@ spec:
                 md5sum $STORE/$file
               done
 
-              # Write $COUNT random files from store and calculate md5
+              # Write $COUNT random files from store
               shuf -n $COUNT -i 0-99 | while read file
               do
                 filename=$(printf "%02d" $file)
                 echo Writing $filename
                 dd if=/dev/urandom of=$STORE/$filename bs=$SIZE count=1
+              done
+
+              # Delete $DEL_COUNT random files from store
+              ls $STORE | shuf -n $DEL_COUNT | while read file
+              do
+                echo Deleting $file
+                rm $STORE/$file
               done
           restartPolicy: Never
           volumes:


### PR DESCRIPTION
# Demo busybot

This is a simple app to fill the demo environment with dummy data. Here's what it does:

1. List files and read a random set of 5 files.
2. Write a random set of 5 files; allow overwrites.
3. List files and delete a random set of 2 files

Each file is of size 50MB. The files are numbered 00-99.

This will be run using a k8s cronjob every two minutes. The yaml file for the cronjob is included in this folder. CephFS is used since filesystem interface is the easiest to use. We will echo the time it took to write/read each file into logs. To ensure the whole file is read, an md5 will be calculated and out in logs.