### PR TITLE
Add check for listening ssh-agent to run.sh

### DIFF
--- a/kubernetes-cluster-kubeone/terraform/terraform.tfvars.example
+++ b/kubernetes-cluster-kubeone/terraform/terraform.tfvars.example
@@ -1,5 +1,6 @@
 cluster_name = "koor-demo"
 ssh_public_key_file = "~/.ssh/id_rsa.pub"
+ssh_private_key_file = "~/.ssh/id_rsa"
 control_plane_vm_count=3
 initial_machinedeployment_replicas=3
 worker_type="cpx41"


### PR DESCRIPTION
The script assumes a listener on SSH_AUTH_SOCK for later operations.  This ensures that there's a listener, and that the key specified in terraform.tfvars has been added.

The caveats are listed in TODO.